### PR TITLE
1_4: Fix issue in internal header, update .gitignore, improve readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.vs
+/.vscode
 /win32
 /win64
+/build

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# OpenXinput
-This library can help you manage more than 4 xinput gamepads on Windows.
+# OpenXInput
+An open-source re-implementation of the XInput driver for Windows that allows for use of more than 4 XInput devices, while maintaining compatibility with standard XInput.
 
-## Why ?
-Because the legit Xinput library can only handle 4 XUSB devices while the underlying driver can handle more, with this library, you can use more than 4 controllers if you want to.
+## Purpose
+Standard XInput can only handle 4 devices, but the underlying XUSB driver can handle more. By using OpenXInput, you can bypass this limitation and set your own controller limit at compile-time.
 
-## How to use ?
-See the [wiki](https://github.com/Nemirtingas/OpenXinput/wiki).
+## Usage
+See the [wiki](../../wiki).

--- a/src/OpenXinputInternal.h
+++ b/src/OpenXinputInternal.h
@@ -21,6 +21,7 @@
     // Build guids, don't need to link against other dll
     #define INITGUID
 #else
+    #include <devguid.h>
     #include <mmdeviceapi.h>
     #include <functiondiscoverykeys.h>
 #endif
@@ -157,7 +158,6 @@ DEFINE_HIDDEN_DEVPROPKEY(static_DEVPKEY_DeviceInterface_ClassGuid, 0x026e516e, 0
     #define XINPUT_DEVINTERFACE_AUDIO_RENDER         static_DEVINTERFACE_AUDIO_RENDER
     #define XINPUT_DEVINTERFACE_AUDIO_CAPTURE        static_DEVINTERFACE_AUDIO_CAPTURE
 #else
-    #include <devguid.h>
     #define XINPUT_IID_IClassFactory                 IID_IClassFactory
     #define XINPUT_IID_IKsPropertySet                IID_IKsPropertySet
 

--- a/src/OpenXinputInternal.h
+++ b/src/OpenXinputInternal.h
@@ -157,6 +157,7 @@ DEFINE_HIDDEN_DEVPROPKEY(static_DEVPKEY_DeviceInterface_ClassGuid, 0x026e516e, 0
     #define XINPUT_DEVINTERFACE_AUDIO_RENDER         static_DEVINTERFACE_AUDIO_RENDER
     #define XINPUT_DEVINTERFACE_AUDIO_CAPTURE        static_DEVINTERFACE_AUDIO_CAPTURE
 #else
+    #include <devguid.h>
     #define XINPUT_IID_IClassFactory                 IID_IClassFactory
     #define XINPUT_IID_IKsPropertySet                IID_IKsPropertySet
 


### PR DESCRIPTION
Found this repository while developing a custom .NET XInput wrapper library, and I can't thank it enough for having all the unnamed ordinals not only named with parameters, but open-source so I can study their behavior if need be.

While checking things out I noticed an issue in OpenXinputInternal.h with one of the GUIDs not being defined when not using static GUIDs, so I tracked down the header file that had it and included it when static GUIDs are not used.

I've also added the `.vscode` and `build` folders to the .gitignore for VS Code settings and the CMake build cache respectively, as well as rewritten the readme for better grammar/readability and replaced the wiki link in it with a relative path instead of a direct one, so future forks link to their own wiki by default instead of the main one (I realize now this might not be the best idea though, when I forked I discovered that the wiki wasn't copied).